### PR TITLE
Feature/ticker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-03-20
+
+### Added
+- **Reactive Clock (Tempo.ticker)**: Introduced the new `static ticker()` method, providing a lightweight way to create high-performance date-time streams using either **Async Generators** (`for await...of`) or callback-based subscriptions.
+- **Ticker Documentation**: Created a dedicated guide `doc/tempo.ticker.md` for reactive clock patterns.
+
+### Changed
+- **Polyfill Decoupling**: Moved the `Temporal` API availability check from the main entry point (`index.ts`) to the core `Tempo` class. This allows standalone utility libraries (`enumify`, `serialize`) to be used in environments without `Temporal` support, while ensuring the engine still provides clear, explicit errors when required.
+
 ## [1.0.8] - 2026-03-19
 
 ### Added

--- a/doc/Tempo.md
+++ b/doc/Tempo.md
@@ -10,11 +10,12 @@ This project came about due to the need for a simple, yet powerful, way to parse
 2. [Parsing](#parsing)
 3. [Formatting](#formatting)
 4. [Manipulation](#manipulation)
-5. [Plugins (Terms)](#plugins-terms)
-6. [Context & Configuration](#context--configuration)
-7. [Enumerators](#enumerators)
-8. [API Reference](./tempo.api.md)
-9. [Cookbook](./tempo.cookbook.md)
+5. [Ticker (Clocks)](#ticker-clocks)
+6. [Plugins (Terms)](#plugins-terms)
+7. [Context & Configuration](#context--configuration)
+8. [Enumerators](#enumerators)
+9. [API Reference](./tempo.api.md)
+10. [Cookbook](./tempo.cookbook.md)
 
 ---
 
@@ -263,6 +264,21 @@ const t1 = new Tempo('2024-05-20', { timeZone: 'America/New_York' });
 const t2 = new Tempo('2024-05-20', { timeZone: 'Europe/London' });
 Tempo.compare(t1, t2); // 1, meaning t1 is 'later than' t2
 ```
+
+---
+
+## Ticker (Clocks)
+
+`Tempo.ticker` creates a reactive stream of `Tempo` instances, making it easy to build clocks or countdowns. It supports both modern **Async Generators** and traditional **Callback Subscriptions**.
+
+```typescript
+// Pattern: Async Generator
+for await (const t of Tempo.ticker(1000)) {
+  console.log(t.format('{hh}:{mi}:{ss}'));
+}
+```
+
+See the [Tempo Ticker guide](./tempo.ticker.md) for full details and API signatures.
 
 ---
 

--- a/doc/Tempo.md
+++ b/doc/Tempo.md
@@ -13,7 +13,7 @@ This project came about due to the need for a simple, yet powerful, way to parse
 5. [Ticker (Clocks)](#ticker-clocks)
 6. [Plugins (Terms)](#plugins-terms)
 7. [Context & Configuration](#context--configuration)
-8. [Enumerators](#enumerators)
+8. [Library Functionality](#library-functionality)
 9. [API Reference](./tempo.api.md)
 10. [Cookbook](./tempo.cookbook.md)
 

--- a/doc/tempo.ticker.md
+++ b/doc/tempo.ticker.md
@@ -1,0 +1,51 @@
+# Tempo Ticker
+
+`Tempo.ticker` is a static method that creates a reactive stream of `Tempo` instances at regular intervals. It is designed to be high-performance and lightweight, providing a simple way to build clocks, countdowns, or scheduled updates.
+
+## Usage Patterns
+
+The ticker supports two modern patterns to fit your development style.
+
+### 1. Async Generator (Stream)
+
+The most modern approach, perfect for `for await...of` loops. This allows you to treat time as an asynchronous stream.
+
+```typescript
+import { Tempo } from '@magmacomputing/tempo';
+
+// emit a new Tempo instance every second
+for await (const t of Tempo.ticker(1000)) {
+  console.log(t.format('{hh}:{mi}:{ss}'));
+}
+```
+
+### 2. Callback Subscription (Hook)
+
+A familiar pattern for UI frameworks (React, Vue, etc.) or simple event-driven logic. It returns a `stop()` function to cleanly cancel the interval.
+
+```typescript
+import { Tempo } from '@magmacomputing/tempo';
+
+// start a ticker
+const stop = Tempo.ticker(1000, (t) => {
+  document.getElementById('clock').innerText = t.format('{hh}:{mi}:{ss}');
+});
+
+// stop it later (e.g. on component unmount)
+stop();
+```
+
+## Performance
+
+`Tempo.ticker` is optimized for zero-overhead:
+- **No extra dependencies**: Relies on native `setInterval` and `AsyncGenerators`.
+- **Instance-per-tick**: Every tick emits a fresh, immutable `Tempo` instance reflecting the exact time of the event.
+- **Explicit Disposal**: The callback pattern provides a direct unsubscribe function to prevent memory leaks.
+
+## API Reference
+
+### `Tempo.ticker(intervalMs: number): AsyncGenerator<Tempo>`
+Creates an infinite stream of `Tempo` instances.
+
+### `Tempo.ticker(intervalMs: number, callback: (t: Tempo) => void): () => void`
+Starts a recurring timer and returns a function to stop it.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,3 @@
-import './temporal.polyfill.js';							              // side-effect runtime check for Temporal
 
 export * from './tempo.class.js';
 export * from './serialize.library.js';                     // stringify, objectify, cloneify functions

--- a/lib/tempo.class.ts
+++ b/lib/tempo.class.ts
@@ -658,7 +658,10 @@ export class Tempo {
 	 */
 	static ticker(intervalMs: number): AsyncGenerator<Tempo>;
 	static ticker(intervalMs: number, callback: (t: Tempo) => void): () => void;
-	static ticker(intervalMs: number, callback?: (t: Tempo) => void): any {
+	static ticker(intervalMs: number, callback?: (t: Tempo) => void): AsyncGenerator<Tempo> | (() => void) {
+		if (typeof intervalMs !== 'number' || !Number.isFinite(intervalMs) || intervalMs <= 0)
+			throw new RangeError('Tempo.ticker: intervalMs must be a finite number > 0')
+
 		if (isFunction(callback)) {
 			const id = setInterval(() => callback(new Tempo()), intervalMs);
 			return () => clearInterval(id);										// stop the interval

--- a/lib/tempo.class.ts
+++ b/lib/tempo.class.ts
@@ -108,7 +108,7 @@ export class Tempo {
 	/** return the Prototype parent of an object */						static #proto(obj: object) { return Object.getPrototypeOf(obj) }
 	/** test object has own property with the given key */		static #hasOwn(obj: object, key: string) { return Object.hasOwn(obj, key) }
 	/** return whether the shape is 'local' or 'global' */		static #isLocal(shape: Tempo.State) { return shape.config.scope === 'local' }
-	/** create an object based on a prototype */							static #create(obj: object, name: string) { return Object.create(Tempo.#proto(obj)[name]) }
+	/** create an object based on a prototype */							static #create<T extends object>(obj: object, name: string): T { return Object.create(Tempo.#proto(obj)[name]) }
 
 	/**
 	 * {dt} is a layout that combines date-related {snippets} (e.g. dd, mm -or- evt) into a pattern against which a string can be tested.  
@@ -763,10 +763,10 @@ export class Tempo {
 	/** underlying Temporal ZonedDateTime */									#zdt!: Temporal.ZonedDateTime;
 	/** temporary anchor used during parsing */								#anchor?: Temporal.ZonedDateTime | undefined;
 	/** prebuilt formats, for convenience */									#fmt = {} as Tempo.Formats;
-	/** instance term plugins */															#term = Object.create(null) as Property<any>;
+	/** instance term plugins */															#term = Object.create(null) as Tempo.Terms;
 	/** instance values to complement static values */				#local = {
 		/** instance configuration */															config: {} as Tempo.Config,
-		/** instance parse rules (only populated if provided) */	parse: {} as Tempo.Parse
+		/** instance parse rules (only populated if provided) */	parse: { result: [] as Tempo.Match[] } as Tempo.Parse
 	} as Tempo.State;
 
 	// #endregion Instance properties
@@ -802,7 +802,7 @@ export class Tempo {
 				})
 
 			if (isDefined(Tempo.#pending)) {											// are we mutating with 'set()' ?
-				(this.#local.parse.result as any[]).unshift(...Tempo.#pending);	// prepend collected parse-matches
+				this.#local.parse.result.unshift(...Tempo.#pending);// prepend collected parse-matches
 				Tempo.#pending = void 0;														// and reset mutating-flag
 			}
 
@@ -2039,6 +2039,9 @@ export namespace Tempo {
 
 	/** Enum registry of format strings */
 	export type Format = Enum.wrap<OwnFormat & Record<string, string | number>>;
+
+	/** mapping of terms to their resolved values */
+	export type Terms = Property<any>;
 
 	/** patterns that return a number */
 	export type NumericPattern = '{yyyy}{mm}' | '{yyww}' | '{yyyy}{mm}{dd}' | '{wy}{ww}' | '{wy}'

--- a/lib/tempo.class.ts
+++ b/lib/tempo.class.ts
@@ -664,13 +664,13 @@ export class Tempo {
 
 		if (isFunction(callback)) {
 			const id = setInterval(() => callback(new Tempo()), intervalMs);
-			return () => clearInterval(id);										// stop the interval
+			return () => clearInterval(id);												// stop the interval
 		}
 
 		return (async function* () {
 			while (true) {
 				await new Promise(resolve => setTimeout(resolve, intervalMs));
-				yield new Tempo();												// emit new Tempo
+				yield new Tempo();																	// emit new Tempo
 			}
 		})();
 	}

--- a/lib/tempo.class.ts
+++ b/lib/tempo.class.ts
@@ -779,12 +779,8 @@ export class Tempo {
 	constructor(tempo: Tempo.DateTime, options?: Tempo.Options);
 	constructor(tempo?: Tempo.DateTime | Tempo.Options, options: Tempo.Options = {}) {
 		this.#now = Temporal.Now.instant();											// stash current Instant
-
-		// swap arguments around, if arg1=Options or Temporal-like
-		[this.#tempo, this.#options] = this.#swap(tempo, options);
-
-		// parse the local options looking for overrides to Tempo.#global.config
-		this.#setLocal(this.#options);
+		[this.#tempo, this.#options] = this.#swap(tempo, options);// swap arguments around, if arg1=Options or Temporal-like
+		this.#setLocal(this.#options);													// parse the local options looking for overrides to Tempo.#global.config
 
 		// we now have all the info we need to instantiate a new Tempo
 		try {

--- a/lib/tempo.class.ts
+++ b/lib/tempo.class.ts
@@ -1,3 +1,5 @@
+import './temporal.polyfill.js';                           	// side-effect runtime check for Temporal
+
 // #region library modules~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 import { Logify } from '#core/shared/logify.class.js';
@@ -636,6 +638,40 @@ export class Tempo {
 
 	static now() { return Temporal.Now.instant().epochNanoseconds; }
 
+	/**
+	 * Creates a reactive ticker that emits a new `Tempo` instance at regular intervals.
+	 * 
+	 * @param intervalMs - The interval in milliseconds between ticks.
+	 * @param callback - Optional callback function to receive each tick.
+	 * @returns If no callback is provided, returns an AsyncGenerator. If a callback is provided, returns a stop function.
+	 * 
+	 * @example
+	 * ```typescript
+	 * // Pattern 1: Async Generator
+	 * for await (const t of Tempo.ticker(1000)) {
+	 *   console.log(t.format('{hh}:{mi}:{ss}'));
+	 * }
+	 * 
+	 * // Pattern 2: Callback Subscription
+	 * const stop = Tempo.ticker(1000, (t) => render(t));
+	 * ```
+	 */
+	static ticker(intervalMs: number): AsyncGenerator<Tempo>;
+	static ticker(intervalMs: number, callback: (t: Tempo) => void): () => void;
+	static ticker(intervalMs: number, callback?: (t: Tempo) => void): any {
+		if (isFunction(callback)) {
+			const id = setInterval(() => callback(new Tempo()), intervalMs);
+			return () => clearInterval(id);										// stop the interval
+		}
+
+		return (async function* () {
+			while (true) {
+				await new Promise(resolve => setTimeout(resolve, intervalMs));
+				yield new Tempo();												// emit new Tempo
+			}
+		})();
+	}
+
 	/** static Tempo.terms getter */
 	static get terms() {
 		return secure(Tempo.#terms
@@ -767,7 +803,7 @@ export class Tempo {
 				})
 
 			if (isDefined(Tempo.#pending)) {											// are we mutating with 'set()' ?
-				this.#local.parse.result.unshift(...Tempo.#pending);	// prepend collected parse-matches
+				(this.#local.parse.result as any[]).unshift(...Tempo.#pending);	// prepend collected parse-matches
 				Tempo.#pending = void 0;														// and reset mutating-flag
 			}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magmacomputing/tempo",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "A premium, high-performance wrapper around the JavaScript Temporal API. A modern, immutable, and fluent alternative to Moment.js, Day.js, and Luxon.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/ticker.test.ts
+++ b/test/ticker.test.ts
@@ -1,0 +1,41 @@
+import { Tempo } from '#core/shared/tempo.class.js';
+
+const label = 'ticker:';
+
+describe(`${label}`, () => {
+
+	test(`${label} callback pattern`, async () => {
+		let count = 0;
+		let lastTick: any;
+
+		const stop = Tempo.ticker(50, (t) => {
+			count++;
+			lastTick = t;
+		});
+
+		await new Promise(resolve => setTimeout(resolve, 200)); // wait for ~4 ticks
+		stop();
+
+		expect(count).toBeGreaterThanOrEqual(3);
+		expect(lastTick?.constructor?.name).toBe('Tempo');
+
+		const finalCount = count;
+		await new Promise(resolve => setTimeout(resolve, 100));
+		expect(count).toBe(finalCount); // check it stopped
+	});
+
+	test(`${label} async generator pattern`, async () => {
+		const ticker = Tempo.ticker(20);
+		const results: any[] = [];
+
+		let i = 0;
+		for await (const t of ticker) {
+			results.push(t);
+			if (++i === 3) break;
+		}
+
+		expect(results.length).toBe(3);
+		expect(results[0]?.constructor?.name).toBe('Tempo');
+	});
+
+});

--- a/test/ticker.test.ts
+++ b/test/ticker.test.ts
@@ -38,4 +38,11 @@ describe(`${label}`, () => {
 		expect(results[0]?.constructor?.name).toBe('Tempo');
 	});
 
+	test(`${label} validation`, () => {
+		expect(() => Tempo.ticker(0)).toThrow(RangeError);
+		expect(() => Tempo.ticker(-1)).toThrow(RangeError);
+		expect(() => Tempo.ticker(NaN)).toThrow(RangeError);
+		expect(() => Tempo.ticker(Infinity)).toThrow(RangeError);
+	});
+
 });

--- a/test/ticker.test.ts
+++ b/test/ticker.test.ts
@@ -1,4 +1,4 @@
-import { Tempo } from '#core/shared/tempo.class.js';
+import { Tempo, isTempo } from '#core/shared/tempo.class.js';
 
 const label = 'ticker:';
 
@@ -17,7 +17,8 @@ describe(`${label}`, () => {
 		stop();
 
 		expect(count).toBeGreaterThanOrEqual(3);
-		expect(lastTick?.constructor?.name).toBe('Tempo');
+		expect(lastTick).toBeDefined();
+		expect(isTempo(lastTick)).toBe(true);
 
 		const finalCount = count;
 		await new Promise(resolve => setTimeout(resolve, 100));
@@ -35,7 +36,8 @@ describe(`${label}`, () => {
 		}
 
 		expect(results.length).toBe(3);
-		expect(results[0]?.constructor?.name).toBe('Tempo');
+		expect(results[0]).toBeDefined();
+		expect(isTempo(results[0])).toBe(true);
 	});
 
 	test(`${label} validation`, () => {


### PR DESCRIPTION
added the Tempo.ticker static method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Tempo.ticker() — reactive clock streams via async-generator (for await...of) or callback subscription with stop control.

* **Documentation**
  * Added a dedicated ticker guide and updated Tempo docs with examples and API reference.

* **Tests**
  * Added unit tests covering callback mode, async-iterator mode and input validation.

* **Chores**
  * Bumped package version to 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->