### PR TITLE
sandbox document

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempo-monorepo",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "private": true,
   "description": "Magma Computing Monorepo",
   "repository": {

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magmacomputing/library",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Shared utility library for Tempo",
   "author": "Magma Computing Solutions",
   "license": "MIT",

--- a/packages/library/src/common/temporal.library.ts
+++ b/packages/library/src/common/temporal.library.ts
@@ -130,5 +130,11 @@ export function normalizeUtcOffset(zone: string): string {
 	if (!match) return zone;
 
 	const [, sign, hours, minutes] = match;
-	return `${sign}${hours.padStart(2,'0')}:${minutes ?? '00'}`;
+	const h = Number(hours);
+	const m = Number(minutes ?? '0');
+
+	// Temporal-valid range: -12:00 .. +14:00, minutes 0..59
+	if (h > 14 || m > 59 || (sign === '+' && h === 14 && m !== 0) || (sign === '-' && h > 12)) return zone;
+
+	return `${sign}${hours.padStart(2, '0')}:${minutes ?? '00'}`;
 }

--- a/packages/library/src/common/temporal.library.ts
+++ b/packages/library/src/common/temporal.library.ts
@@ -118,3 +118,17 @@ export function getTemporalIds(tz: any, cal: any): [string, string] {
 
 	return [tzId || 'UTC', calId || 'iso8601'];
 }
+
+/**
+ * ## normalizeUtcOffset
+ * Convert informal UTC offset strings into the `±HH:MM` format required by Temporal.
+ * Accepts forms like `'UTC+8'`, `'UTC-9'`, `'UTC+08:00'`, `'UTC-05:30'`.
+ * Returns the input unchanged if it does not match the UTC± pattern.
+ */
+export function normalizeUtcOffset(zone: string): string {
+	const match = /^UTC([+-])(\d{1,2})(?::(\d{2}))?$/i.exec(zone);
+	if (!match) return zone;
+
+	const [, sign, hours, minutes] = match;
+	return `${sign}${hours.padStart(2,'0')}:${minutes ?? '00'}`;
+}

--- a/packages/tempo/doc/architecture.md
+++ b/packages/tempo/doc/architecture.md
@@ -66,22 +66,21 @@ Together, these ensure that `new Tempo()` maintains an $O(1)$ constructor execut
 
 ---
 
-## 🔁 Iteration & Enumerability (The Shadowing Chain)
+## 🔁 Iteration & Enumerability (Delegator Proxies)
 
-When using prototype shadowing, the JavaScript behavior for property inspection changes significantly. This is a trade-off for the performance gains.
+Tempo now uses delegator Proxies for `fmt` and `term`, not prototype shadow-chain relocation. Enumeration behavior is therefore more standard and predictable than in earlier releases of Tempo.
 
-### ⚠️ The `Object.keys()` Warning
-`Object.keys(instance.fmt)` only returns the **enumerable own properties** of the current link in the shadowing chain.
-- **Initially**: Returns `[]` (all evaluated getters are non-enumerable on the base).
-- **After 1st Access** (e.g., `.date`): Returns `['date']`.
-- **After 2nd Access** (e.g., `.time`): Returns `['time']`. The `.date` property is now located on the **immediate prototype** of the current object.
+### ✅ `Object.keys()` Behavior
+`Object.keys(instance.fmt)` and `Object.keys(instance.term)` return the enumerable own keys currently registered on each delegator target.
 
-### 🛡️ The Flattening Iterator
-Tempo implements a **Flattening Iterator** via `[Symbol.iterator]` which enables iterable consumers like `for...of`, array spread (`[...instance]`), and `Object.fromEntries(instance)` to traverse the shadowing chain (using `Object.getPrototypeOf`) and collect evaluated property entries.
+- **Discovery on enumeration**: Calling `Object.keys(...)` triggers proxy discovery, which pre-registers available keys as enumerable lazy getters.
+- **Before direct access**: Keys can already be visible and probeable.
+- **After access**: Access memoizes values on the same target object; keys remain stable and do not "move" across prototype links.
 
-- **`[Symbol.iterator]`**: Traverses the shadowing chain to provide a flattened view of all computed state.
-- **⚠️ Important**: `for...in` and object spread (`{...instance}`) **do not** use the iterator; instead, they rely on enumerable own/inherited properties and are not supported by the flattening logic.
-- **`Tempo.formats` & `Tempo.terms`**: These static getters continue to provide a registry-wide view of **available** keys across the entire system, regardless of their evaluation state.
+### 🛡️ Iteration Notes
+- **`Object.keys` / `for...in` / object spread**: Operate on enumerable keys exposed by the delegator target after discovery.
+- **`[Symbol.iterator]`**: Still provides explicit iterator semantics where implemented.
+- **`Tempo.formats` & `Tempo.terms`**: These static getters continue to provide a registry-wide view of available keys across the system, independent of per-instance memoization state.
 
 ---
 

--- a/packages/tempo/doc/architecture.md
+++ b/packages/tempo/doc/architecture.md
@@ -68,14 +68,17 @@ Together, these ensure that `new Tempo()` maintains an $O(1)$ constructor execut
 
 ## 🔁 Iteration & Enumerability (Delegator Proxies)
 
-Tempo now uses delegator Proxies for `fmt` and `term`, not prototype shadow-chain relocation. Enumeration behavior is therefore more standard and predictable than in earlier releases of Tempo.
+A delegator Proxy is a Proxy wrapper whose traps forward operations to an internal target/handler pair; unlike a standard Proxy (which typically mediates access directly against one wrapped target object), delegation is explicit and routed through that intermediate forwarding layer. In Tempo, "delegator Proxy" and "Generic Lazy Delegator Proxy" refer to the same public delegation mechanism, while lazy shadowing for `Tempo.#term`/`Tempo.#fmt` is a separate private-field initialization mechanism. These mechanisms coexist: the `instance.term` / `instance.fmt` public API uses the delegator Proxy path, and `Tempo.#term` / `Tempo.#fmt` private fields are initialized once via lazy shadowing.
 
 ### ✅ `Object.keys()` Behavior
 `Object.keys(instance.fmt)` and `Object.keys(instance.term)` return the enumerable own keys currently registered on each delegator target.
 
-- **Discovery on enumeration**: Calling `Object.keys(...)` triggers proxy discovery, which pre-registers available keys as enumerable lazy getters.
+- **Proxy discovery (definition)**: Proxy discovery is the proxy-handler phase that enumerates available target keys and installs enumerable lazy getter properties on the proxy target without reading their values.
+- **Triggered by enumeration APIs**: Discovery runs when enumeration APIs execute, including `Object.keys(instance.fmt)`, `for...in`, and `Reflect.ownKeys(...)` on the delegator proxy.
+- **Timing**: Discovery happens at enumeration time (before any property `get`), so key visibility is established before value resolution.
 - **Before direct access**: Keys can already be visible and probeable.
-- **After access**: Access memoizes values on the same target object; keys remain stable and do not "move" across prototype links.
+- **Relation to [Section 1](#1-lazy-evaluation-shadowing)**: Discovery only registers getters; actual value computation and memoization happen later, when a getter is first invoked (for example, `instance.fmt.someKey`).
+- **After access**: Getter access memoizes values on the same target object; keys remain stable and do not "move" across prototype links.
 
 ### 🛡️ Iteration Notes
 - **`Object.keys` / `for...in` / object spread**: Operate on enumerable keys exposed by the delegator target after discovery.

--- a/packages/tempo/doc/migration-guide.md
+++ b/packages/tempo/doc/migration-guide.md
@@ -86,13 +86,13 @@ As Tempo grows, it has become much more efficient for our developers to logicall
 2.  Replace any older internal paths with the current package subpath entries (for example, `@magmacomputing/tempo/duration`, `@magmacomputing/tempo/mutate`, `@magmacomputing/tempo/parse`, and `@magmacomputing/tempo/format`).
 3.  Do not pin imports in your code directly to internal folder layouts in `dist/`, since those paths may change as modules are reorganized.  Instead rely wholly on your import maps.
 
-## 🔁 Migrating to version 2.6.0
+## 🔁 Migrating from version 2.6.0
 
 Season term scope output has been simplified.
 
 **Action Required**:
 1.  If you previously relied on the Chinese-specific object attached to `term.season` scope output, remove that dependency.
-2.  Resolve Chinese season context by creating a dedicated `Tempo` instance with the appropriate Chinese `timeZone` (or explicit `sphere`) for the interpretation you need.
+2.  Resolve Chinese season context by creating a dedicated `Tempo` instance with the appropriate Chinese `timeZone` for the interpretation you need.
 
 ## 🧪 Testing and Stability
 v2.x has been hardened with a 100% pass rate on our regression suite. If you were relying on undocumented "quirks" or bugs in v1.x parsing, you may find that v2.x is more strict and deterministic.

--- a/packages/tempo/doc/migration-guide.md
+++ b/packages/tempo/doc/migration-guide.md
@@ -86,5 +86,13 @@ As Tempo grows, it has become much more efficient for our developers to logicall
 2.  Replace any older internal paths with the current package subpath entries (for example, `@magmacomputing/tempo/duration`, `@magmacomputing/tempo/mutate`, `@magmacomputing/tempo/parse`, and `@magmacomputing/tempo/format`).
 3.  Do not pin imports in your code directly to internal folder layouts in `dist/`, since those paths may change as modules are reorganized.  Instead rely wholly on your import maps.
 
+## 🔁 Migrating to version 2.6.0
+
+Season term scope output has been simplified.
+
+**Action Required**:
+1.  If you previously relied on the Chinese-specific object attached to `term.season` scope output, remove that dependency.
+2.  Resolve Chinese season context by creating a dedicated `Tempo` instance with the appropriate Chinese `timeZone` (or explicit `sphere`) for the interpretation you need.
+
 ## 🧪 Testing and Stability
 v2.x has been hardened with a 100% pass rate on our regression suite. If you were relying on undocumented "quirks" or bugs in v1.x parsing, you may find that v2.x is more strict and deterministic.

--- a/packages/tempo/doc/releases/v2.x.md
+++ b/packages/tempo/doc/releases/v2.x.md
@@ -2,7 +2,25 @@
 
 ## [v2.6.0] - 2026-04-25
 ### ⚠️ Migration Notes
-- **Season Scope Simplification**: Removed the Chinese-specific object previously attached to all `term.season` scope's output. For Chinese season interpretation, create a dedicated `Tempo` instance with `{timeZone: 'Asia/Shanghai'}` or `{timeZone: '+08:00'}}.  Note that Chinese zodiac will still be supported on `term.zodiac.CN` as before.
+
+
+- New Features
+
+Added normalizeUtcOffset utility for transforming informal UTC-offset strings to standard format.
+Added layoutOrder option to customize parsing element precedence.
+- Breaking Changes
+- **Season Scope Simplification**: Removed the Chinese-specific object previously attached to all `term.season` scope's output. For Chinese season interpretation, create a dedicated `Tempo` instance with `{timeZone: 'Asia/Shanghai'}` or `{timeZone: '+08:00'}`.  Note that Chinese zodiac will still be supported on `term.zodiac.CN` as before.
+
+
+- Bug Fixes
+
+Fixed layout pattern resolution ordering to respect intended sequence.
+Enhanced timezone normalization for UTC offset handling.
+- Documentation
+
+Updated architecture documentation and configuration guidance.
+Clarified plugin/module callback parameter ordering in examples.
+Added v2.6.0 migration guide for season changes.
 
 ## [v2.5.0] -2026-04-25
 ### New Features

--- a/packages/tempo/doc/releases/v2.x.md
+++ b/packages/tempo/doc/releases/v2.x.md
@@ -1,4 +1,9 @@
 # 📜 Version 2.x History
+
+## [v2.6.0] - 2026-04-25
+### ⚠️ Migration Notes
+- **Season Scope Simplification**: Removed the Chinese-specific object previously attached to all `term.season` scope's output. For Chinese season interpretation, create a dedicated `Tempo` instance with `{timeZone: 'Asia/Shanghai'}` or `{timeZone: '+08:00'}}.  Note that Chinese zodiac will still be supported on `term.zodiac.CN` as before.
+
 ## [v2.5.0] -2026-04-25
 ### New Features
 

--- a/packages/tempo/doc/sandbox-factory.md
+++ b/packages/tempo/doc/sandbox-factory.md
@@ -9,7 +9,7 @@ Historically, `Tempo.init()` modified the global library state. This meant that:
 3. Testing multiple configurations required careful cleanup between tests.
 
 ## The Solution
-`Tempo.create()` returns a **derived sandboxed class**. You may optionally pass configuration options to seed that sandbox. Each derived class maintains its own isolated `State` and `Registry`.
+`Tempo.create()` returns a **derived class** with its own isolated configuration, registry, and plugin state. Each sandbox inherits from the caller, but runs with independent internal state.
 
 ### Example: Creating a Sandbox
 ```typescript
@@ -58,7 +58,7 @@ console.log(t.parse.result);
 ```
 
 ## Immutability & Security
-Sandboxed classes created via `Tempo.create()` are protected by the same `@Immutable` and `@Serializable` decorators as the base class. 
+Sandboxed classes created via `Tempo.create()` are protected by the same `@Immutable` and `@Serializable` decorators as the base class.
 - The Sandbox class itself is hardened against static member modification.
 - Instances of the Sandbox are frozen upon construction.
 - The internal state is stored in a `WeakMap`, inaccessible to external code.

--- a/packages/tempo/doc/sandbox-factory.md
+++ b/packages/tempo/doc/sandbox-factory.md
@@ -9,14 +9,14 @@ Historically, `Tempo.init()` modified the global library state. This meant that:
 3. Testing multiple configurations required careful cleanup between tests.
 
 ## The Solution
-`Tempo.init()` now returns a **derived class** when provided with configuration options. Each derived class maintains its own isolated `State` and `Registry`.
+`Tempo.create()` returns a **derived sandboxed class**. You may optionally pass configuration options to seed that sandbox. Each derived class maintains its own isolated `State` and `Registry`.
 
 ### Example: Creating a Sandbox
 ```typescript
 import { Tempo } from '@magmacomputing/tempo';
 
 // Create a specialized Sandbox for a Financial app
-const FinTempo = Tempo.init({
+const FinTempo = Tempo.create({
   period: {
     'market-open': '09:30',
     'market-close': '16:00'
@@ -34,7 +34,7 @@ When using sandboxes, it's important to know which configuration resolved an inp
 ### Hierarchy of Resolution
 When a conflict occurs (e.g., you redefine "noon"), Tempo uses a **"Last One Wins"** strategy:
 1. **Local (Instance)**: Options passed to `new Tempo(val, options)`.
-2. **Sandbox (Factory)**: Options passed to `Tempo.init(options)`.
+2. **Sandbox (Factory)**: Options passed to `Tempo.create(options)`.
 3. **Plugins**: Aliases registered via `Tempo.extend()`.
 4. **Global Defaults**: Built-in aliases like "xmas", "midnight", etc.
 
@@ -58,7 +58,7 @@ console.log(t.parse.result);
 ```
 
 ## Immutability & Security
-Sandboxed classes created via `Tempo.init()` are protected by the same `@Immutable` and `@Serializable` decorators as the base class. 
+Sandboxed classes created via `Tempo.create()` are protected by the same `@Immutable` and `@Serializable` decorators as the base class. 
 - The Sandbox class itself is hardened against static member modification.
 - Instances of the Sandbox are frozen upon construction.
 - The internal state is stored in a `WeakMap`, inaccessible to external code.

--- a/packages/tempo/doc/sandbox-factory.md
+++ b/packages/tempo/doc/sandbox-factory.md
@@ -9,7 +9,7 @@ Historically, `Tempo.init()` modified the global library state. This meant that:
 3. Testing multiple configurations required careful cleanup between tests.
 
 ## The Solution
-`Tempo.create()` returns a **derived class** with its own isolated configuration, registry, and plugin state. Each sandbox inherits from the caller, but runs with independent internal state.
+`Tempo.create()` returns a **derived sandboxed class** with its own isolated configuration, registry, and plugin state. Each sandbox inherits from the caller, but runs with independent internal state.
 
 ### Example: Creating a Sandbox
 ```typescript

--- a/packages/tempo/doc/tempo.config.md
+++ b/packages/tempo/doc/tempo.config.md
@@ -43,21 +43,53 @@ Tempo.init({ store: 'userSettings' });
 
 ## 2. Global Discovery
 
-To facilitate configuration in micro-frontend architectures or when using a `<script>` tag, Tempo automatically "discovers" a global configuration object before any instances are created.
+To facilitate configuration in micro-frontend architectures or script-first bootstraps, Tempo can discover a Discovery object from globalThis during Tempo.init().
 
-### Using a Static Method (Recommended)
-This is the most secure and ergonomic method to provide configuration, and is compatible with ESM hoisting.
+The intended flow is:
+1. Write a Discovery object into globalThis under the configured discovery symbol key.
+2. Import a module containing Tempo.
+3. Tempo class static initialization runs Tempo.init().
+4. Tempo.init() reads the global discovery slot and merges it.
+
+By default, the key is Symbol.for('$Tempo').
+
+### Pre-Bootstrap Discovery (globalThis)
+
+```javascript
+// Must run before the first Tempo module is evaluated
+globalThis[Symbol.for('$Tempo')] = {
+  options: { timeZone: 'Europe/Paris' },
+  timeZones: { MYTZ: 'Asia/Dubai' },
+  formats: { myFormat: '{dd}!!{mm}!!{yyyy}' },
+  terms: [myCustomTermPlugin]
+};
+
+// Load Tempo after the discovery object is in place
+const { Tempo } = await import('@magmacomputing/tempo');
+```
+
+::: info
+With static ESM imports, import evaluation happens before module body execution. If you need discovery to apply on first load, assign globalThis in an earlier script/module, or use dynamic import as shown above.
+:::
+
+### Explicit Runtime Registration (Not Global Discovery)
+Using Tempo.extend(...) is explicit registration after Tempo is loaded. It is ergonomic and strongly recommended for normal application code, but it is a different mechanism from pre-bootstrap global discovery.
 
 ```javascript
 import { Tempo } from '@magmacomputing/tempo';
 
 Tempo.extend({
-   options: { timeZone: 'Europe/Paris' },
-   timeZones: { 'MYTZ': 'Asia/Dubai' },
-   formats: { 'myFormat': '{dd}!!{mm}!!{yyyy}' },
-   terms: [ myCustomTermPlugin ]
- });
+  options: { timeZone: 'Europe/Paris' },
+  timeZones: { MYTZ: 'Asia/Dubai' },
+  formats: { myFormat: '{dd}!!{mm}!!{yyyy}' },
+  terms: [myCustomTermPlugin]
+});
 ```
+
+### Security and Ergonomics Notes
+- Global Discovery is convenient for host-controlled bootstraps and cross-bundle handoff.
+- Tempo.extend(...) is usually safer in app code because configuration is explicit, local, and easier to trace.
+- Use Global Discovery when you must configure Tempo before the first Tempo import executes.
 
 ### Discovery Contract
 Tempo looks for the following structure:

--- a/packages/tempo/doc/tempo.config.md
+++ b/packages/tempo/doc/tempo.config.md
@@ -43,15 +43,15 @@ Tempo.init({ store: 'userSettings' });
 
 ## 2. Global Discovery
 
-To facilitate configuration in micro-frontend architectures or script-first bootstraps, Tempo can discover a Discovery object from globalThis during Tempo.init().
+To facilitate configuration in micro-frontend architectures or script-first bootstraps, `Tempo` can discover a Discovery object from `globalThis` during `Tempo.init()`.
 
 The intended flow is:
-1. Write a Discovery object into globalThis under the configured discovery symbol key.
-2. Import a module containing Tempo.
-3. Tempo class static initialization runs Tempo.init().
-4. Tempo.init() reads the global discovery slot and merges it.
+1. Write a Discovery object into `globalThis` under the configured discovery symbol key.
+2. Import a module containing `Tempo`.
+3. `Tempo` class static initialization runs `Tempo.init()`.
+4. `Tempo.init()` reads the global discovery slot and merges it.
 
-By default, the key is Symbol.for('$Tempo').
+By default, the key is `Symbol.for('$Tempo')`.
 
 ### Pre-Bootstrap Discovery (globalThis)
 
@@ -69,11 +69,11 @@ const { Tempo } = await import('@magmacomputing/tempo');
 ```
 
 ::: info
-With static ESM imports, import evaluation happens before module body execution. If you need discovery to apply on first load, assign globalThis in an earlier script/module, or use dynamic import as shown above.
+With static ESM imports, import evaluation happens before module body execution. If you need discovery to apply on first load, assign `globalThis` in an earlier script/module, or use dynamic `import()` as shown above.
 :::
 
 ### Explicit Runtime Registration (Not Global Discovery)
-Using Tempo.extend(...) is explicit registration after Tempo is loaded. It is ergonomic and strongly recommended for normal application code, but it is a different mechanism from pre-bootstrap global discovery.
+Using `Tempo.extend(...)` is explicit registration after `Tempo` is loaded. It is ergonomic and strongly recommended for normal application code, but it is a different mechanism from pre-bootstrap global discovery.
 
 ```javascript
 import { Tempo } from '@magmacomputing/tempo';
@@ -88,8 +88,8 @@ Tempo.extend({
 
 ### Security and Ergonomics Notes
 - Global Discovery is convenient for host-controlled bootstraps and cross-bundle handoff.
-- Tempo.extend(...) is usually safer in app code because configuration is explicit, local, and easier to trace.
-- Use Global Discovery when you must configure Tempo before the first Tempo import executes.
+- `Tempo.extend(...)` is usually safer in app code because configuration is explicit, local, and easier to trace.
+- Use Global Discovery when you must configure `Tempo` before the first `Tempo` import executes.
 
 ### Discovery Contract
 Tempo looks for the following structure:

--- a/packages/tempo/doc/tempo.modularity.md
+++ b/packages/tempo/doc/tempo.modularity.md
@@ -85,7 +85,7 @@ You can create your own modules to extend Tempo's internal engine or its public 
 ```typescript
 import { defineModule } from '@magmacomputing/tempo/plugin';
 
-export const MyModule = defineModule((options, TempoClass) => {
+export const MyModule = defineModule((TempoClass, options) => {
     // Add instance methods
     TempoClass.prototype.sayHello = function() { return 'Hello!'; };
     

--- a/packages/tempo/doc/tempo.plugin.md
+++ b/packages/tempo/doc/tempo.plugin.md
@@ -27,9 +27,9 @@ import { definePlugin } from '@magmacomputing/tempo/plugin';
 
 export const MyPlugin = definePlugin((TempoClass, options, factory) => {
   /**
-   * TempoClass: The internal Tempo class (for static methods)
+  * TempoClass: The internal Tempo class (for static methods)
   * options:    The global configuration object
-   * factory:    A helper to create new Tempo instances without 'new'
+  * factory:    A helper to create new Tempo instances without 'new'
    */
 
   // 1. Add a static method

--- a/packages/tempo/doc/tempo.plugin.md
+++ b/packages/tempo/doc/tempo.plugin.md
@@ -25,10 +25,10 @@ The most efficient way to author a plugin is using the `definePlugin` factory. T
 ```typescript
 import { definePlugin } from '@magmacomputing/tempo/plugin';
 
-export const MyPlugin = definePlugin((options, TempoClass, factory) => {
+export const MyPlugin = definePlugin((TempoClass, options, factory) => {
   /**
-   * options:    The global configuration object
    * TempoClass: The internal Tempo class (for static methods)
+  * options:    The global configuration object
    * factory:    A helper to create new Tempo instances without 'new'
    */
 
@@ -48,7 +48,7 @@ If you prefer not to use the factory (e.g. for plugin that should *not* self-reg
 ```typescript
 import type { Tempo } from '@magmacomputing/tempo/core';
 
-export const ManualPlugin: Tempo.Plugin = (options, TempoClass, factory) => {
+export const ManualPlugin: Tempo.Plugin = (TempoClass, options, factory) => {
   // ... implementation ...
 };
 ```
@@ -197,7 +197,7 @@ class MyPluginInstance implements MyPluginTypes.Descriptor {
 Use a `Proxy` in your `definePlugin` factory to handle the callability trap. This allows your plugin to act as a function (the shortcut) and an object (the stateful class) simultaneously.
 
 ```typescript
-export const MyPlugin = definePlugin((options, TempoClass, factory) => {
+export const MyPlugin = definePlugin((TempoClass, options, factory) => {
   (TempoClass as any).myTool = function(arg1: any): MyPluginTypes.Instance {
     const instance = new MyPluginInstance(arg1);
     
@@ -229,7 +229,7 @@ If your plugin requires its own configuration, export a **factory function** tha
 import { defineModule } from '@magmacomputing/tempo/plugin';
 
 export const HolidayModule = (pluginOptions = {}) => {
-  return defineModule((tempoOptions, TempoClass, factory) => {
+  return defineModule((TempoClass, tempoOptions, factory) => {
     // ... use pluginOptions here ...
   });
 };
@@ -244,7 +244,7 @@ import { defineModule } from '@magmacomputing/tempo/plugin';
 import { PluginA } from './plugin.a.js';
 import { PluginB } from './plugin.b.js';
 
-export const MyFeatureModule = defineModule((options, TempoClass) => {
+export const MyFeatureModule = defineModule((TempoClass, options) => {
   TempoClass.extend([PluginA, PluginB]);
 });
 ```

--- a/packages/tempo/package.json
+++ b/packages/tempo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magmacomputing/tempo",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "The Tempo core library",
   "author": "Magma Computing Solutions",
   "license": "MIT",
@@ -232,7 +232,7 @@
   },
   "devDependencies": {
     "@js-temporal/polyfill": "^0.5.1",
-    "@magmacomputing/library": "2.5.0",
+    "@magmacomputing/library": "2.6.0",
     "@rollup/plugin-alias": "^6.0.0",
     "cross-env": "^7.0.3",
     "magic-string": "^0.30.21",

--- a/packages/tempo/plan/slick-syntax-duration-keys.md
+++ b/packages/tempo/plan/slick-syntax-duration-keys.md
@@ -1,0 +1,92 @@
+# Slick Syntax Extension for Duration Keys
+
+## Status
+- Proposed for a future release (not scheduled in the current release).
+- Intent: evaluate design and rollout without breaking existing term-based Slick behavior.
+
+## Context
+Today, Slick Syntax is centered on Term mutation resolution (for example `#term` and `#term.modifier` forms).
+Mutation routing for object inputs currently distinguishes:
+- Term-style mutations (`#...` or discovered term plugins)
+- Standard unit mutations (`year`, `month`, `week`, `day`, etc.)
+- Parser-backed set operations (`period`, `event`, `time`, `date`, `dow`, `wkd`)
+
+This creates an opportunity to support human-friendly modifier strings on selected duration/unit keys.
+
+## Goal
+Allow selected non-term mutation keys to accept Slick-style strings, starting with the most intuitive use-cases.
+
+Example candidate syntax:
+- `t1.set({ week: ">2Mon" })`
+
+## Key Architectural Principle
+Keep two concepts distinct:
+- Term Slick: range-based/cycle-aware term navigation.
+- Unit Slick: field-oriented mutation grammar interpreted per key.
+
+Do not merge these conceptually into one generic resolver until semantics are explicit and deterministic per key.
+
+## Why Not Full Unification Immediately
+Term ranges and unit fields have different semantics:
+- Terms represent named cyclical windows.
+- Duration keys represent arithmetic or calendar-field operations.
+
+A single generic parser without key-scoped rules risks ambiguous behavior and regressions.
+
+## Proposed Direction
+Introduce key-scoped Slick handling for duration/unit keys in phases.
+
+### Phase 1 (Recommended First Step)
+Add Slick support for weekday-style keys only:
+- `wkd`
+- `dow`
+
+Rationale:
+- Strong existing parser support for weekday-relative logic.
+- Lowest ambiguity.
+- High utility for natural expressions.
+
+### Phase 2
+Evaluate `week` key support with explicit semantics.
+
+Possible contract (to validate):
+- `">2Mon"` means advance to the second next Monday using a defined week anchor policy.
+
+Must define:
+- What is the anchor week?
+- How cross-boundary transitions are counted.
+- Whether current-week matches are included/excluded.
+
+### Phase 3 (Optional)
+Evaluate month/year key Slick forms only after policies are formalized for overflow and day clamping.
+
+## Suggested Semantics Guardrails
+- Parse grammar should be key-aware, not global.
+- Unsupported key+pattern combinations should throw descriptive errors.
+- Keep existing numeric/object mutation behavior unchanged.
+- Preserve term Slick behavior exactly unless explicitly version-gated.
+
+## Compatibility & Risk Notes
+- Main risk: user confusion between term and unit semantics when both accept similar modifiers.
+- Mitigation:
+  - Explicit per-key docs and examples.
+  - Validation errors for unsupported combinations.
+  - Incremental rollout with tests per key.
+
+## Testing Strategy (Future)
+- Add table-driven tests per supported key (`wkd`, `dow`, later `week`).
+- Include boundary tests across month/year transitions.
+- Include timezone-sensitive cases.
+- Add regression tests proving existing term Slick behavior is unchanged.
+
+## Open Questions
+1. Should `week` Slick be interpreted relative to current date, start-of-week, or nearest matching weekday?
+2. Should symbolic modifiers (`>`, `>=`, `<`, `<=`) map exactly to current term Slick semantics?
+3. Do we allow number words (`two`) in unit Slick counts, or numbers only?
+4. Should this ship behind a parse/mutate option flag first?
+
+## Recommendation
+Proceed with a conservative, phased implementation:
+1. Formal spec for `wkd`/`dow` first.
+2. Implement + test + document.
+3. Evaluate `week` syntax (`">2Mon"`) after semantics are signed off.

--- a/packages/tempo/plan/slick-syntax-duration-keys.md
+++ b/packages/tempo/plan/slick-syntax-duration-keys.md
@@ -18,6 +18,7 @@ Allow selected non-term mutation keys to accept Slick-style strings, starting wi
 
 Example candidate syntax:
 - `t1.set({ week: ">2Mon" })`
+`t1.set({ week: ">2Mon" })` - advances to the 2nd following Monday.
 
 ## Key Architectural Principle
 Keep two concepts distinct:
@@ -41,6 +42,19 @@ Add Slick support for weekday-style keys only:
 - `wkd`
 - `dow`
 
+Illustrative Phase 1 examples:
+```javascript
+// assign by weekday name (short/full)
+t1.set({ wkd: 'Mon' });
+t1.set({ wkd: 'Monday' });
+
+// relative token: move to the next occurrence of the current weekday
+t1.set({ dow: 'next' });
+
+// numeric-relative offset: advance N weekdays
+t1.set({ dow: '>2' });
+```
+
 Rationale:
 - Strong existing parser support for weekday-relative logic.
 - Lowest ambiguity.
@@ -50,7 +64,7 @@ Rationale:
 Evaluate `week` key support with explicit semantics.
 
 Possible contract (to validate):
-- `">2Mon"` means advance to the second next Monday using a defined week anchor policy.
+- `">2Mon"` means advance to the second following Monday using a defined week anchor policy.
 
 Must define:
 - What is the anchor week?
@@ -63,6 +77,9 @@ Evaluate month/year key Slick forms only after policies are formalized for overf
 ## Suggested Semantics Guardrails
 - Parse grammar should be key-aware, not global.
 - Unsupported key+pattern combinations should throw descriptive errors.
+  - Illustrative template (invalid pattern for `month` key): `Invalid Slick pattern for key "month": ">>3". Expected numeric offset or supported month-token form.`
+  - Illustrative template (unsupported week-anchor modifier): `Unsupported week-anchor modifier for key "week": "^Mon". Supported modifiers are ">", ">=", "<", "<=" with a valid weekday anchor.`
+  - These are illustrative templates for consistent feedback when throwing key+pattern validation errors in Slick syntax parsing logic.
 - Keep existing numeric/object mutation behavior unchanged.
 - Preserve term Slick behavior exactly unless explicitly version-gated.
 
@@ -72,20 +89,35 @@ Evaluate month/year key Slick forms only after policies are formalized for overf
   - Explicit per-key docs and examples.
   - Validation errors for unsupported combinations.
   - Incremental rollout with tests per key.
+  - Backward compatibility: Scan for existing Slick patterns that could collide with new unit-key syntax, add compatibility tests for known legacy patterns, and use a staged deprecation/rollout strategy (for example opt-in flag + warnings before default-on behavior).
+  - Performance: Measure parser impact in hot paths, publish benchmark/profile results, and add mitigation tactics such as caching parse results and fast-path guards for common valid forms.
 
 ## Testing Strategy (Future)
-- Add table-driven tests per supported key (`wkd`, `dow`, later `week`).
-- Include boundary tests across month/year transitions.
-- Include timezone-sensitive cases.
-- Add regression tests proving existing term Slick behavior is unchanged.
+- Add table-driven tests for each supported key (`wkd`, `dow`, `week`).
+- For each key (`wkd`, `dow`, `week`), include explicit edge-case categories:
+  - DST transitions (spring-forward/fall-back behavior).
+  - Leap-year boundaries (Feb 29 <-> Feb 28).
+  - End-of-month rollovers (for example Jan 31 -> Feb 28/29).
+  - Cross-year transitions (Dec -> Jan).
+- For each edge-case category, include timezone-sensitive variants.
+- Add regression tests proving existing Slick term behavior is unchanged.
 
 ## Open Questions
 1. Should `week` Slick be interpreted relative to current date, start-of-week, or nearest matching weekday?
 2. Should symbolic modifiers (`>`, `>=`, `<`, `<=`) map exactly to current term Slick semantics?
+  - Recommended answer (Question 2): Yes. Symbolic modifiers (`>`, `>=`, `<`, `<=`) should map exactly to current term Slick semantics to preserve consistency and reduce cognitive load for existing users.
+  - Justification: Reusing established modifier behavior minimizes migration friction, strengthens backward-compatibility expectations, and avoids introducing a second mental model for nearly identical syntax.
+  - Action item (implementation/testing): Codify an explicit operator mapping table shared between term and unit Slick paths, and add parity tests plus backward-compatibility regression tests proving modifier behavior is unchanged.
 3. Do we allow number words (`two`) in unit Slick counts, or numbers only?
 4. Should this ship behind a parse/mutate option flag first?
 
 ## Recommendation
+### Timeline & Priority (Optional)
+- Priority: Medium
+- Estimated effort:
+  - Phase 1 (`wkd`/`dow`): ~2-3 days (spec + implementation + tests + docs)
+  - Phase 2 (`week`): ~3-5 days due to additional semantic complexity
+
 Proceed with a conservative, phased implementation:
 1. Formal spec for `wkd`/`dow` first.
 2. Implement + test + document.

--- a/packages/tempo/src/discrete/discrete.parse.ts
+++ b/packages/tempo/src/discrete/discrete.parse.ts
@@ -264,7 +264,16 @@ const _ParseEngine = {
 		let zdt = dateTime as any;
 		const anchorTime = zdt.toPlainTime();
 
-		for (const [symKey, pat] of state.parse.pattern) {
+		const orderedPatterns = (ownEntries(state.parse.layout) as [PropertyKey, string][])
+			.map(([layoutKey]) => {
+				const symKey = typeof layoutKey === 'symbol'
+					? layoutKey
+					: (state.parse.token?.[String(layoutKey)] as symbol | undefined);
+				return [symKey, symKey ? state.parse.pattern.get(symKey) : undefined] as const;
+			});
+
+		for (const [symKey, pat] of orderedPatterns) {
+			if (!symKey || !pat) continue;
 			const groups = _ParseEngine.parseMatch(state, pat, trim);
 			if (isEmpty(groups)) {
 				continue;

--- a/packages/tempo/src/engine/engine.layout.ts
+++ b/packages/tempo/src/engine/engine.layout.ts
@@ -65,6 +65,7 @@ export function resolveLayoutClassificationOrder(layout: Record<symbol, string>,
 		const resolvedName = TOKEN_DESCRIPTION_BY_NAME.get(name) ?? name;
 		const entry = byName.get(resolvedName) ?? byName.get(name);
 		if (!entry) return;
+		if (seen.has(entry[0])) return;
 		seen.add(entry[0]);
 		next.push(entry);
 	});

--- a/packages/tempo/src/engine/engine.layout.ts
+++ b/packages/tempo/src/engine/engine.layout.ts
@@ -1,8 +1,21 @@
 import { ownEntries } from '#library/primitive.library.js';
+import { Token } from '#tempo/support/tempo.symbol.js';
 import type * as t from '../tempo.type.js';
 
 export type LayoutEntry = [symbol, string];
 export type LayoutController = Record<PropertyKey, string[]>;
+
+const TOKEN_ALIAS = new Map<symbol, string>(
+	(ownEntries(Token, true) as [string, symbol][]).map(([name, key]) => [key, name])
+);
+
+// Support alias-driven ordering regardless of symbol identity by resolving
+// token names (e.g. dt, wkd, tm) to their symbol descriptions.
+const TOKEN_DESCRIPTION_BY_NAME = new Map<string, string>(
+	(ownEntries(Token, true) as [string, symbol][])
+		.map(([name, key]) => [name, key.description ?? ''] as const)
+		.filter(([, description]) => description.length > 0)
+);
 
 export const DEFAULT_LAYOUT_CLASS: unique symbol = Symbol('default');
 
@@ -38,12 +51,19 @@ export function resolveLayoutClassificationOrder(layout: Record<symbol, string>,
 	if (preferred.length === 0) return layout;
 
 	const entries = ownEntries(layout) as LayoutEntry[];
-	const byName = new Map(entries.map(([key, value]) => [key.description ?? '', [key, value] as LayoutEntry]));
+	const byName = new Map<string, LayoutEntry>();
+	entries.forEach(([key, value]) => {
+		const description = key.description ?? '';
+		if (description) byName.set(description, [key, value]);
+		const alias = TOKEN_ALIAS.get(key);
+		if (alias) byName.set(alias, [key, value]);
+	});
 	const next: LayoutEntry[] = [];
 	const seen = new Set<symbol>();
 
 	preferred.forEach(name => {
-		const entry = byName.get(name);
+		const resolvedName = TOKEN_DESCRIPTION_BY_NAME.get(name) ?? name;
+		const entry = byName.get(resolvedName) ?? byName.get(name);
 		if (!entry) return;
 		seen.add(entry[0]);
 		next.push(entry);

--- a/packages/tempo/src/plugin/term/term.season.ts
+++ b/packages/tempo/src/plugin/term/term.season.ts
@@ -15,12 +15,6 @@ const ranges = [
 	{ key: 'Summer', day: 1, month: 12, symbol: 'Sun', group: 'meteorological', sphere: COMPASS.South },
 	{ key: 'Autumn', day: 1, month: 3, symbol: 'Leaf', group: 'meteorological', sphere: COMPASS.South },
 	{ key: 'Winter', day: 1, month: 6, symbol: 'Snowflake', group: 'meteorological', sphere: COMPASS.South },
-
-	// Chinese
-	{ key: 'Spring', day: 1, month: 3, symbol: 'Flower', group: 'chinese', trait: 'A time of renewal and growth' },
-	{ key: 'Summer', day: 1, month: 6, symbol: 'Sun', group: 'chinese', trait: 'A period of heat and fruition' },
-	{ key: 'Autumn', day: 1, month: 9, symbol: 'Leaf', group: 'chinese', trait: 'A time for harvest and contraction' },
-	{ key: 'Winter', day: 1, month: 12, symbol: 'Snowflake', group: 'chinese', trait: 'A period of stillness and consolidation' },
 ];
 
 /** definition of meteorological season ranges */
@@ -29,12 +23,6 @@ const groups = defineRange(ranges, 'group', 'sphere');
 /** resolve the full candidate list for the current context */
 function resolve(t: Tempo, anchor?: any) {
 	const list = resolveCycleWindow(t, groups, { anchor, groupBy: ['group', 'sphere'], group: 'meteorological' });
-
-	// append Chinese trait information as an additional metadata field (CN)
-	// const chinese = ranges.filter((g: any) => g.group === 'chinese');
-	// list.forEach((itm: any) => itm['CN'] = getTermRange(t, chinese, false, anchor));
-	// This was removed as it added complexity without clear value; the Chinese traits are already included in the base range definitions and
-	// should more-properly be surfaced by a new Tempo() with a Chinese-specific timeZone.
 
 	return list;
 }
@@ -46,7 +34,7 @@ function resolve(t: Tempo, anchor?: any) {
 export const SeasonTerm = defineTerm({
 	key: 'szn',
 	scope: 'season',
-	description: 'Meteorogical season',
+	description: 'Meteorological season',
 	groups,
 
 	resolve(this: Tempo, anchor?: any) {

--- a/packages/tempo/src/plugin/term/term.season.ts
+++ b/packages/tempo/src/plugin/term/term.season.ts
@@ -31,8 +31,10 @@ function resolve(t: Tempo, anchor?: any) {
 	const list = resolveCycleWindow(t, groups, { anchor, groupBy: ['group', 'sphere'], group: 'meteorological' });
 
 	// append Chinese trait information as an additional metadata field (CN)
-	const chinese = ranges.filter((g: any) => g.group === 'chinese');
-	list.forEach((itm: any) => itm['CN'] = getTermRange(t, chinese, false, anchor));
+	// const chinese = ranges.filter((g: any) => g.group === 'chinese');
+	// list.forEach((itm: any) => itm['CN'] = getTermRange(t, chinese, false, anchor));
+	// This was removed as it added complexity without clear value; the Chinese traits are already included in the base range definitions and
+	// should more-properly be surfaced by a new Tempo() with a Chinese-specific timeZone.
 
 	return list;
 }

--- a/packages/tempo/src/support/tempo.default.ts
+++ b/packages/tempo/src/support/tempo.default.ts
@@ -189,5 +189,6 @@ export const Default = secure({
 	/** default locale if not specified */										locale: getDateTimeFormat().locale,
 	/** locales that prefer month-day order */								mdyLocales: ['en-US', 'en-AS'],	/** @link https:	//en.wikipedia.org/wiki/Date_format_by_country */
 	/** layouts that need to swap parse-order */							mdyLayouts: [['dayMonthYearShort', 'monthDayYearShort'], ['dayMonthYear', 'monthDayYear']],
+	/** preferred parse-order of layouts */										layoutOrder: [],
 	/** hemisphere for term.qtr or term.szn */								sphere: undefined,
 } as Options)

--- a/packages/tempo/src/support/tempo.enum.ts
+++ b/packages/tempo/src/support/tempo.enum.ts
@@ -207,7 +207,7 @@ export type ZONED_DATE_TIME = ValueOf<typeof ZONED_DATE_TIME>
 export type ZonedDateTime = KeyOf<typeof ZONED_DATE_TIME>
 
 /** allowed keys for Tempo configuration options */
-const optionKeys = ['value', 'mode', 'mdyLocales', 'mdyLayouts', 'store', 'discovery', 'debug', 'catch', 'timeZone', 'calendar', 'locale', 'pivot', 'sphere', 'timeStamp', 'snippet', 'layout', 'event', 'period', 'formats', 'plugins'] as const;
+const optionKeys = ['value', 'mode', 'mdyLocales', 'mdyLayouts', 'layoutOrder', 'store', 'discovery', 'debug', 'catch', 'timeZone', 'calendar', 'locale', 'pivot', 'sphere', 'timeStamp', 'snippet', 'layout', 'event', 'period', 'formats', 'plugins'] as const;
 export const OPTION = enumify(optionKeys, false);
 export type Option = KeyOf<typeof OPTION>
 
@@ -216,7 +216,7 @@ export const MODE = enumify({ Auto: 'auto', Strict: 'strict', Defer: 'defer', },
 export type MODE = ValueOf<typeof MODE>
 
 /** allowed keys for internal parse state */
-const parseKeys = ['mdyLocales', 'mdyLayouts', 'formats', 'pivot', 'snippet', 'layout', 'event', 'period', 'anchor', 'value', 'discovery', 'plugins', 'mode'] as const;
+const parseKeys = ['mdyLocales', 'mdyLayouts', 'layoutOrder', 'formats', 'pivot', 'snippet', 'layout', 'event', 'period', 'anchor', 'value', 'discovery', 'plugins', 'mode'] as const;
 export const PARSE = enumify(parseKeys, false);
 export type Parse = KeyOf<typeof PARSE>
 

--- a/packages/tempo/src/support/tempo.init.ts
+++ b/packages/tempo/src/support/tempo.init.ts
@@ -2,6 +2,7 @@ import '#library/temporal.polyfill.js';
 import { enumify } from '#library/enumerate.library.js';
 import { asArray } from '#library/coercion.library.js';
 import { getDateTimeFormat, getHemisphere } from '#library/international.library.js';
+import { normalizeUtcOffset } from '#library/temporal.library.js';
 import { markConfig } from '#library/symbol.library.js';
 import { asType } from '#library/type.library.js';
 import { isString, isObject, isUndefined, isDefined, isRegExp } from '#library/assertion.library.js';
@@ -39,6 +40,7 @@ export function init(options: t.Options = {}, isGlobal = true, baseState?: t.Int
 		ignore: baseState ? { ...baseState.parse.ignore } : Object.fromEntries(asArray(Ignore).map(w => [w, w])),
 		mdyLocales: asArray(baseState?.parse.mdyLocales ?? Default.mdyLocales as any),
 		mdyLayouts: asArray<t.Pair>(baseState?.parse.mdyLayouts ?? Default.mdyLayouts as any),
+		layoutOrder: asArray<string>(baseState?.parse.layoutOrder ?? Default.layoutOrder as any),
 		pivot: (baseState?.parse.pivot ?? Default.pivot) as any,
 		mode: (baseState?.parse.mode ?? Default.mode) as any,
 		lazy: false,
@@ -136,9 +138,15 @@ export function extendState(state: t.Internal.State, options: t.Options) {
 				break;
 			}
 
+			case 'layoutOrder':
+				state.parse.layoutOrder = asArray(arg.value)
+					.map(v => String(v).trim())
+					.filter(Boolean);
+				break;
+
 			case 'timeZone': {
 				const zone = String(arg.value).toLowerCase();
-				const resolvedZone = enums.TIMEZONE[zone] ?? arg.value;
+				const resolvedZone = enums.TIMEZONE[zone] ?? normalizeUtcOffset(String(arg.value));
 				setProperty(state.config, 'timeZone', resolvedZone);
 				setProperty(state.config, 'sphere', getHemisphere(resolvedZone));
 				break;

--- a/packages/tempo/src/support/tempo.init.ts
+++ b/packages/tempo/src/support/tempo.init.ts
@@ -9,7 +9,7 @@ import { isString, isObject, isUndefined, isDefined, isRegExp } from '#library/a
 import { ownEntries } from '#library/primitive.library.js';
 
 import { getRuntime } from './tempo.runtime.js';
-import { setProperty, hasOwn, create, collect, setPatterns } from './tempo.util.js';
+import { setProperty, hasOwn, create, collect, setPatterns, normalizeLayoutOrder } from './tempo.util.js';
 import { sym, Token } from './tempo.symbol.js';
 import { Match, Snippet, Layout, Event, Period, Ignore, Guard, Default } from './tempo.default.js';
 import enums, { STATE } from './tempo.enum.js';
@@ -139,9 +139,7 @@ export function extendState(state: t.Internal.State, options: t.Options) {
 			}
 
 			case 'layoutOrder':
-				state.parse.layoutOrder = asArray(arg.value)
-					.map(v => String(v).trim())
-					.filter(Boolean);
+				state.parse.layoutOrder = normalizeLayoutOrder(arg.value);
 				break;
 
 			case 'timeZone': {

--- a/packages/tempo/src/support/tempo.util.ts
+++ b/packages/tempo/src/support/tempo.util.ts
@@ -1,11 +1,19 @@
 import { sym, Token } from './tempo.symbol.js';
 import { asType } from '#library/type.library.js';
+import { asArray } from '#library/coercion.library.js';
 import { isSymbol, isUndefined, isString, isRegExp, isNullish, isObject, isEmpty } from '#library/assertion.library.js';
 import { ownEntries, ownKeys } from '#library/primitive.library.js';
 import { getRuntime } from './tempo.runtime.js';
 import { Match, Snippet, Layout } from './tempo.default.js';
 import enums from './tempo.enum.js';
 import type * as t from '../tempo.type.js';
+
+/** @internal normalize layout-order options into a clean string array */
+export function normalizeLayoutOrder(value: unknown): string[] {
+	return asArray(value)
+		.map(v => String(v).trim())
+		.filter(Boolean);
+}
 
 /** @internal set a mutable, enumerable property on a target */
 export const setProperty = <T>(target: object, key: PropertyKey, value: T) =>

--- a/packages/tempo/src/tempo.class.ts
+++ b/packages/tempo/src/tempo.class.ts
@@ -19,11 +19,11 @@ import { registerPlugin, interpret, ensureModule } from './plugin/plugin.util.js
 import { registerTerm, getTermRange } from './plugin/term.util.js';
 import { DEFAULT_LAYOUT_CLASS, resolveLayoutOrder, getLayoutOrder } from './engine/engine.layout.js';
 import type { TermPlugin, Plugin } from './plugin/plugin.type.js';
-import { setProperty, proto, hasOwn, create, compileRegExp, setPatterns } from './support/tempo.util.js';
+import { setProperty, proto, hasOwn, create, compileRegExp, setPatterns, normalizeLayoutOrder } from './support/tempo.util.js';
 
 import { sym, markConfig, TermError, getRuntime, init, isTempo, registryUpdate, registryReset, onRegistryReset, Match, Token, Snippet, Layout, Event, Period, Ignore, Default, Guard, enums, STATE, DISCOVERY, $Internal, $setConfig, $logError, $logDebug, $Identity, $setEvents, $setPeriods, $buildGuard, $IsBase, type TempoBrand, $Tempo, $Register, $Logify, $errored, $dbg, $guard, $Discover, $setDiscovery } from '#tempo/support';
 import * as t from './tempo.type.js';												// namespaced types (Tempo.*)
-import { instant } from '#library/temporal.library.js';
+import { instant, normalizeUtcOffset } from '#library/temporal.library.js';
 
 declare module '#library/type.library.js' {
 	interface TypeValueMap<T> {
@@ -383,9 +383,7 @@ export class Tempo {
 						break;
 
 					case 'layoutOrder':
-						shape.parse.layoutOrder = asArray(arg.value as NonNullable<t.Options[typeof optKey]>)
-							.map(v => String(v).trim())
-							.filter(Boolean);
+						shape.parse.layoutOrder = normalizeLayoutOrder(arg.value as NonNullable<t.Options[typeof optKey]>);
 						break;
 
 					case 'pivot':
@@ -397,8 +395,10 @@ export class Tempo {
 						break;
 
 					case 'timeZone': {
-						const zone = arg.value.toString().toLowerCase();
-						setProperty(shape.config, 'timeZone', enums.TIMEZONE[zone] ?? arg.value);
+						const zone = String(arg.value).toLowerCase();
+						const resolvedZone = enums.TIMEZONE[zone] ?? normalizeUtcOffset(String(arg.value));
+						setProperty(shape.config, 'timeZone', resolvedZone);
+						setProperty(shape.config, 'sphere', getHemisphere(resolvedZone));
 						break;
 					}
 

--- a/packages/tempo/src/tempo.class.ts
+++ b/packages/tempo/src/tempo.class.ts
@@ -17,7 +17,7 @@ import { getDateTimeFormat, getHemisphere, canonicalLocale } from '#library/inte
 
 import { registerPlugin, interpret, ensureModule } from './plugin/plugin.util.js'
 import { registerTerm, getTermRange } from './plugin/term.util.js';
-import { resolveLayoutOrder, getLayoutOrder } from './engine/engine.layout.js';
+import { DEFAULT_LAYOUT_CLASS, resolveLayoutOrder, getLayoutOrder } from './engine/engine.layout.js';
 import type { TermPlugin, Plugin } from './plugin/plugin.type.js';
 import { setProperty, proto, hasOwn, create, compileRegExp, setPatterns } from './support/tempo.util.js';
 
@@ -229,10 +229,15 @@ export class Tempo {
 	 * this allows the parser to try to interpret '04012023' as Apr-01-2023 before trying 04-Jan-2023  
 	 */
 	static #swapLayout(shape: Internal.State) {
+		const layoutController = shape.parse.layoutOrder.length > 0
+			? { [DEFAULT_LAYOUT_CLASS]: [...shape.parse.layoutOrder] }
+			: undefined;
+
 		const layout = resolveLayoutOrder({
 			layout: shape.parse.layout,
 			mdyLayouts: shape.parse.mdyLayouts,
 			isMonthDay: !!shape.parse.isMonthDay,
+			...(layoutController !== undefined && { layoutController }),
 		});
 
 		if (layout !== shape.parse.layout)
@@ -377,6 +382,12 @@ export class Tempo {
 						shape.parse[optKey] = asArray(arg.value as NonNullable<t.Options[typeof optKey]>);
 						break;
 
+					case 'layoutOrder':
+						shape.parse.layoutOrder = asArray(arg.value as NonNullable<t.Options[typeof optKey]>)
+							.map(v => String(v).trim())
+							.filter(Boolean);
+						break;
+
 					case 'pivot':
 						shape.parse["pivot"] = Number(arg.value);
 						break;
@@ -432,7 +443,7 @@ export class Tempo {
 
 		shape.config.sphere = Tempo.#setSphere(shape, mergedOptions);
 
-		if (isDefined(shape.parse.mdyLocales)) Tempo.#swapLayout(shape);
+		Tempo.#swapLayout(shape);
 		if (isDefined(shape.parse.event)) (this as any)[$setEvents](shape);
 		if (isDefined(shape.parse.period)) (this as any)[$setPeriods](shape);
 
@@ -640,7 +651,7 @@ export class Tempo {
 
 					registerPlugin(arg);
 					try {
-						(arg as any)(options, this, (val: any) => new this(val));
+						(arg as any)(this, options, (val: any) => new this(val));
 					} catch (e: any) {
 						const msg = (e?.message ?? '').toLowerCase();
 						if (msg.includes('constructor') || msg.includes('class') || (e instanceof TypeError) || isClass(arg)) {
@@ -786,6 +797,7 @@ export class Tempo {
 			parse.pattern ??= new Map<symbol, RegExp>();
 			parse.mdyLocales = Tempo.#mdyLocales(Default.mdyLocales as t.Options['mdyLocales']);
 			parse.mdyLayouts = asArray(Default.mdyLayouts as t.Options['mdyLayouts']) as t.Pair[];
+			parse.layoutOrder = asArray(Default.layoutOrder as t.Options['layoutOrder']) as string[];
 			parse.pivot ??= Default.pivot as any;
 			parse.mode ??= Default.mode as any;
 			parse.lazy = false;
@@ -974,6 +986,7 @@ export class Tempo {
 			ignore: { ...parse.ignore },
 			mdyLocales: [...parse.mdyLocales],
 			mdyLayouts: [...parse.mdyLayouts],
+			layoutOrder: [...parse.layoutOrder],
 			mode: parse.mode
 		});
 	}

--- a/packages/tempo/src/tempo.type.ts
+++ b/packages/tempo/src/tempo.type.ts
@@ -160,6 +160,7 @@ export namespace Internal {
 		/** initialization strategy ('auto'|'strict'|'defer') */mode?: enums.MODE;
 		/** locale-names that prefer 'mm-dd-yy' date order */		mdyLocales: string | string[];
 		/** swap parse-order of layouts */											mdyLayouts: Pair[];
+		/** preferred parse-order of layouts */									layoutOrder: string[];
 		/** date-time snippets to help compose a Layout */			snippet: Snippet | PatternOption<Pattern>;
 		/** patterns to help parse value */											layout: Layout | PatternOption<Pattern>;
 		/** custom date aliases (events). */										event: Event | PatternOption<Logic>;
@@ -208,6 +209,7 @@ export namespace Internal {
 	export interface Parse {
 		/** Locales which prefer 'mm-dd-yyyy' date-order */			mdyLocales: ({ locale: string, timeZones: string[] } | string)[];
 		/** Layout names that are switched to mdy */						mdyLayouts: Pair[];
+		/** preferred parse-order of layouts */									layoutOrder: string[];
 		/** is a timeZone that prefers 'mmddyyyy' date order */	isMonthDay?: boolean;
 		/** Symbol registry */																	token: Token;
 		/** Tempo snippets to aid in parsing */									snippet: Snippet;
@@ -228,7 +230,7 @@ export namespace Internal {
 	}
 
 	/** drop the parse-only Options */
-	export type OptionsKeep = Omit<BaseOptions, "mdyLocales" | "mdyLayouts" | "pivot" | "snippet" | "layout" | "event" | "period" | "ignore" | "value">
+	export type OptionsKeep = Omit<BaseOptions, "mdyLocales" | "mdyLayouts" | "layoutOrder" | "pivot" | "snippet" | "layout" | "event" | "period" | "ignore" | "value">
 
 	/** Instance configuration derived from supply, storage, and discovery. */
 	export interface Config extends Required<Omit<OptionsKeep, "formats">> {

--- a/packages/tempo/test/engine.layout.test.ts
+++ b/packages/tempo/test/engine.layout.test.ts
@@ -94,4 +94,28 @@ describe('engine.layout resolver', () => {
 		expect(classified).toBe(layout);
 		expect(orderOf(classified)).toEqual(['hms', 'dmy6', 'mdy6', 'ymd6']);
 	});
+
+	test('supports token-key aliases in preferred layout ordering', () => {
+		const layout = makeLayout(['hourMinuteSecond', 'weekDay', 'date', 'time']);
+		const classified = resolveLayoutClassificationOrder(layout, {
+			[DEFAULT_LAYOUT_CLASS]: ['wkd', 'dt', 'tm'],
+		}, DEFAULT_LAYOUT_CLASS);
+
+		expect(orderOf(classified)).toEqual(['weekDay', 'date', 'time', 'hourMinuteSecond']);
+	});
+
+	test('applies preferred order before month-day swaps', () => {
+		const layout = makeLayout(['dayMonthYear', 'monthDayYear', 'weekDay', 'date', 'time']);
+		const resolved = resolveLayoutOrder({
+			layout,
+			mdyLayouts: [['dayMonthYear', 'monthDayYear']],
+			isMonthDay: true,
+			layoutController: {
+				[DEFAULT_LAYOUT_CLASS]: ['wkd', 'dt', 'tm', 'dmy', 'mdy'],
+			},
+			classification: DEFAULT_LAYOUT_CLASS,
+		});
+
+		expect(orderOf(resolved)).toEqual(['weekDay', 'date', 'time', 'monthDayYear', 'dayMonthYear']);
+	});
 });

--- a/packages/tempo/test/layout.order.test.ts
+++ b/packages/tempo/test/layout.order.test.ts
@@ -110,4 +110,12 @@ describe('layout matching order', () => {
 			expect(t.parse.result?.[0]?.match).toBe('yearMonthDayShort');
 		}
 	});
+
+	test('supports layoutOrder option to customize precedence', () => {
+		Tempo.init({ layoutOrder: ['dt', 'wkd'] });
+		const t = new Tempo('monday', { timeZone: 'UTC' });
+
+		expect(Tempo.parse.layoutOrder).toEqual(['dt', 'wkd']);
+		expect(t.parse.result?.[0]?.match).toBe('date');
+	});
 });

--- a/packages/tempo/test/sandbox-factory.test.ts
+++ b/packages/tempo/test/sandbox-factory.test.ts
@@ -26,20 +26,33 @@ describe('Sandbox Factory Pattern', () => {
 	});
 
 	it('should support shadowing global aliases', () => {
-		// Global 'noon' is 12:00
-		const EarlyNoon = Tempo.create({
-			period: {
-				'noon': '11:00'
-			}
-		});
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-		// Original remains unaffected (if not manually reset in a way that changes it)
-		// We expect 12:00 for the base Tempo
-		const t1 = new Tempo('noon');
-		expect(t1.hh).toBe(12);
+		try {
+			// Global 'noon' is 12:00
+			const EarlyNoon = Tempo.create({
+				period: {
+					'noon': '11:00'
+				}
+			});
 
-		const t2 = new EarlyNoon('noon');
-		expect(t2.hh).toBe(11);
+			// Original remains unaffected (if not manually reset in a way that changes it)
+			// We expect 12:00 for the base Tempo
+			const t1 = new Tempo('noon');
+			expect(t1.hh).toBe(12);
+
+			const t2 = new EarlyNoon('noon');
+			expect(t2.hh).toBe(11);
+
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Potential period alias collision: "noon" overlaps with existing alias(es): after[ -]?noon')
+			);
+			expect(errSpy).not.toHaveBeenCalled();
+		} finally {
+			warnSpy.mockRestore();
+			errSpy.mockRestore();
+		}
 	});
 
 	it('should record traceability info in parse results', () => {

--- a/packages/tempo/test/season_metadata.test.ts
+++ b/packages/tempo/test/season_metadata.test.ts
@@ -6,5 +6,6 @@ describe('Season Metadata Resolution', () => {
         const q = t.term.season as any;
         
         expect(q.key).toBe('Spring');
+           expect(q.CN).toBeUndefined();
     });
 });

--- a/packages/tempo/test/season_metadata.test.ts
+++ b/packages/tempo/test/season_metadata.test.ts
@@ -1,12 +1,10 @@
 import { Tempo } from '#tempo';
 
 describe('Season Metadata Resolution', () => {
-    it('should resolve meteorological seasons and Chinese trait metadata', () => {
+    it('should resolve meteorological seasons', () => {
         const t = new Tempo('2024-05-15', { sphere: 'north' }); // Spring in North
         const q = t.term.season as any;
         
         expect(q.key).toBe('Spring');
-        expect(q.CN).toBeDefined();
-        expect(q.CN.trait).toContain('renewal');
     });
 });


### PR DESCRIPTION
Correct the wording on Tempo.create functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v2.6.0

* **New Features**
  * Added `normalizeUtcOffset` utility for transforming informal UTC-offset strings to standard format.
  * Added `layoutOrder` option to customize parsing element precedence.

* **Breaking Changes**
  * Removed Chinese-specific metadata from season scope output. Create a dedicated instance with appropriate timezone for Chinese season interpretation.

* **Bug Fixes**
  * Fixed layout pattern resolution ordering to respect intended sequence.
  * Enhanced timezone normalization for UTC offset handling.

* **Documentation**
  * Updated architecture documentation and configuration guidance.
  * Clarified plugin/module callback parameter ordering in examples.
  * Added v2.6.0 migration guide for season changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->